### PR TITLE
Missing comma in settings example

### DIFF
--- a/modules/cbi18n/instructions.md
+++ b/modules/cbi18n/instructions.md
@@ -22,7 +22,7 @@ i18n = {
     // The storage to use for user's locale: session, client, cookie, request
     localeStorage = "cookie",
     // The value to show when a translation is not found
-    unknownTranslation = "**NOT FOUND**"
+    unknownTranslation = "**NOT FOUND**",
     // Extra resource bundles to load
     resourceBundles = {
         alias = "path"


### PR DESCRIPTION
Very minor, but there was a missing comma in the example code that might cause confusion if copied directly