### PR TITLE
Fixes module failure when wirebox.singletonreload is on

### DIFF
--- a/modules/cbi18n/ModuleConfig.cfc
+++ b/modules/cbi18n/ModuleConfig.cfc
@@ -37,7 +37,8 @@ component {
 	* Fired when the module is registered and activated.
 	*/
 	function onLoad(){
-		parseParentSettings();
+		var using_i18n = parseParentSettings();
+		if(using_i18n) wirebox.getInstance( "i18n@cbi18n" ).configure();
 	}
 
 	/**


### PR DESCRIPTION
When wirebox.singletonreload is set to true, calls to `getResource()` and `getFwLocale()` will produce the error "The LocaleStorage setting cannot be found. Please make sure you create the i18n elements."

Calling the base configure() of the cbi18n instance on Module load ensures the default resource bundle and locale storage are always available.