### PR TITLE
Implements the ability to specify a custom resource service

### DIFF
--- a/modules/cbi18n/ModuleConfig.cfc
+++ b/modules/cbi18n/ModuleConfig.cfc
@@ -80,7 +80,8 @@ component {
 					localeStorage = "",
 					unknownTranslation = "",
 					logUnknownTranslation = false,
-					resourceBundles = {}
+					resourceBundles = {},
+					customResourceService = ""
 				};
 				// Append incoming structure
 				structAppend( modules[ thisModule ].i18n, i18nSettings, true );
@@ -102,10 +103,21 @@ component {
 					controller.setSetting( "localeStorage", modules[ thisModule ].i18n.localeStorage );
 					flagi18n = true;
 				}
+				
+				if( len( modules[ thisModule ].i18n.customResourceService ) AND NOT len( controller.getSetting( "customResourceService" ) ) ){
+					binder.map( "ResourceService@cbi18n", true ).to( "shared.model.extensions.plugins.ResourceService" );
+					flagi18n = true;
+				}
+
 				if( structCount( modules[ thisModule ].i18n.resourceBundles ) ){
 					structAppend( controller.getSetting( "resourceBundles" ), modules[ thisModule ].i18n.resourceBundles, true );
 					flagi18n = true;
 				}
+
+				if( len( controller.getSetting( "customResourceService" ) ) ){
+					binder.map( "resourceService@cbi18n", true ).to( getSetting( "customResourceService" ) );
+				}
+				
 				if( flagi18n ){
 					controller.setSetting( "using_i18N", true );
 				}

--- a/readme.md
+++ b/readme.md
@@ -41,11 +41,13 @@ i18n = {
     localeStorage = "cookie",
     // The value to show when a translation is not found
     unknownTranslation = "**NOT FOUND**",
-    logUnknownTranslation = true | false
+    logUnknownTranslation = true | false,
     // Extra resource bundles to load
     resourceBundles = {
         alias = "path"
-    }
+    },
+    //Specify a Custom Resource Service, which should implement the methods or extend the base i18n ResourceService ( e.g. - using a database to store i18n )
+    customResourceService = ""
 };
 ```
 


### PR DESCRIPTION
This adds functionality to specify a custom resource service to allow for customized i18n implementations. (e.g. - Database storage).  

When the plugin architecture was removed from CB4, previous implementations which used the `extensions/plugins` conventions to override the i18n implementation became incompatible with this module.

This module will allow for upgrade capability to CB4 for those CB3 plugin extensions by creating a new setting of `customResourceService` which will overrides the `resourceService@cbi18n` mapping.